### PR TITLE
Add workflow to import opportunity epics to roadmap board

### DIFF
--- a/.github/workflows/import-opportunity-epics.yml
+++ b/.github/workflows/import-opportunity-epics.yml
@@ -1,0 +1,82 @@
+name: Import opportunity epics automatically
+
+on:
+  schedule:
+    # :17 past every hour. Off-the-hour deliberately: on-the-hour cron jobs
+    # are heavily delayed by GitHub due to load.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+# Prevents two scheduled runs from overlapping if one runs long.
+concurrency:
+  group: import-opportunity-epics
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find epics with roadmap parent and add to board
+        env:
+          GH_TOKEN: ${{ secrets.ROADMAP_BOARD_PAT }}
+        run: |
+          set -euo pipefail
+
+          # Resolve project ID once.
+          PROJECT_ID=$(gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org) {
+                projectV2(number: $number) { id }
+              }
+            }' -F org="home-assistant" -F number=45 --jq '.data.organization.projectV2.id')
+
+          echo "Project ID: $PROJECT_ID"
+
+          # Page through open issues, pulling parent info.
+          CURSOR="null"
+          PROCESSED=0
+
+          while : ; do
+            RESPONSE=$(gh api graphql -f query='
+              query($cursor: String) {
+                repository(owner: "home-assistant", name: "epics") {
+                  issues(states: OPEN, first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      number
+                      parent {
+                        repository { nameWithOwner }
+                      }
+                    }
+                  }
+                }
+              }' -F cursor="$CURSOR")
+
+            # Filter to issues whose parent is in the roadmap repo.
+            MATCHES=$(echo "$RESPONSE" | jq -r '
+              .data.repository.issues.nodes[]
+              | select(.parent.repository.nameWithOwner == "OpenHomeFoundation/roadmap")
+              | "\(.id) \(.number)"')
+
+            while IFS=' ' read -r ISSUE_ID ISSUE_NUM; do
+              [ -z "$ISSUE_ID" ] && continue
+              # Idempotent: returns existing item if already on the board.
+              gh api graphql -f query='
+                mutation($project: ID!, $item: ID!) {
+                  addProjectV2ItemById(input: {projectId: $project, contentId: $item}) {
+                    item { id }
+                  }
+                }' -F project="$PROJECT_ID" -F item="$ISSUE_ID" > /dev/null
+              echo "Ensured epic #$ISSUE_NUM on board"
+              PROCESSED=$((PROCESSED + 1))
+            done <<< "$MATCHES"
+
+            HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.repository.issues.pageInfo.hasNextPage')
+            if [ "$HAS_NEXT" != "true" ]; then break; fi
+            CURSOR=$(echo "$RESPONSE" | jq -r '.data.repository.issues.pageInfo.endCursor')
+          done
+
+          echo "Done. Processed $PROCESSED epics with roadmap parents."


### PR DESCRIPTION
## What

Adds a scheduled workflow that hourly sweeps open issues in this repo and adds any with a parent in `OpenHomeFoundation/roadmap` to project board #45 (Home Assistant roadmap).

## Why

Epics created via the roadmap opportunity's sub-issue UI already land on the board through the project's built-in "Auto-add sub-issues" workflow. But epics created standalone and linked as a sub-issue afterwards don't, because the sub-issue link doesn't fire an event that the built-in workflow can react to.

This is the common path when epics are drafted in tooling outside the GitHub UI, then linked to their opportunity once filed, which happens regularly. Result: epics quietly miss the board until someone notices.

## How

One scheduled workflow, runs at :17 past every hour. For each open issue in `home-assistant/epics`, checks via GraphQL whether its parent is in the roadmap repo, and if so calls `addProjectV2ItemById` on project #45. Epics already added are skipped.

Also exposes `workflow_dispatch` so it can be triggered manually from the Actions tab when you don't want to wait up to an hour.

## Requirements

Repo secret `ROADMAP_BOARD_PAT` needs to exist before this workflow can succeed. Token scopes required:

- Org-level `Projects: Read and write` on `home-assistant` (fine-grained PAT), or classic `project` scope
- Repo read on `home-assistant/epics` and `OpenHomeFoundation/roadmap` (fine-grained: `Contents: Read`, `Issues: Read`; classic: `repo`)

The roadmap read is needed for the parent lookup. Cross-org because roadmap lives under `OpenHomeFoundation`.

## Out of scope

- Realtime trigger on `issues.opened`. Considered, but for the way epics actually get created here it would rarely catch anything the hourly sweep wouldn't, and adds a second file to maintain. Can revisit if hour-of-lag turns out to matter.
- Opportunities with tasks but no epic. Tasks in other repos wouldn't be picked up by a workflow scoped to this repo. Separate problem, future iteration.
- Removing items from the board. This only adds. Stale items still need manual grooming or a separate workflow. This is likely solvable with a simple filtering out of completed items.

## Testing

After merge and once the secret is in place, the first scheduled run (or a manual dispatch from the Actions tab) will add any currently-unboarded open epics with a roadmap parent. Expected to backfill a small number of epics that should already be on the board but aren't.